### PR TITLE
Set 'entry_id' as unique

### DIFF
--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -14,6 +14,9 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.7.1" date="2015-10-01" min="2.5">
+			- Support Symphony 2.5+
+		</release>
 		<release version="1.7" date="2014-12-22" min="2.5">
 			- Support Symphony 2.5+
 		</release>

--- a/fields/field.number.php
+++ b/fields/field.number.php
@@ -42,7 +42,7 @@
 				  `entry_id` int(11) unsigned NOT NULL,
 				  `value` double default NULL,
 				  PRIMARY KEY  (`id`),
-				  KEY `entry_id` (`entry_id`),
+				  UNIQUE KEY `entry_id` (`entry_id`),
 				  KEY `value` (`value`)
 				) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci"
 			);


### PR DESCRIPTION
On a rather busy symphony install I encountered some nasty bugs, that
were caused by duplicate database entries in number-field-tables.

According to the discussions in the following issues this change should
prevent this behaviour:

https://github.com/symphonists/order_entries/pull/40
https://github.com/symphonycms/uniqueinputfield/issues/8